### PR TITLE
Benchmark correctness

### DIFF
--- a/src/main/java/com/mkyong/benchmark/BenchmarkForwardReverseLoop.java
+++ b/src/main/java/com/mkyong/benchmark/BenchmarkForwardReverseLoop.java
@@ -1,6 +1,7 @@
 package com.mkyong.benchmark;
 
 import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
 import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.RunnerException;
 import org.openjdk.jmh.runner.options.Options;
@@ -15,11 +16,13 @@ import java.util.concurrent.TimeUnit;
 @Fork(value = 1, jvmArgs = {"-Xms2G", "-Xmx2G"})
 @Warmup(iterations = 5)
 @Measurement(iterations = 10)
+@State(Scope.Benchmark)
 public class BenchmarkForwardReverseLoop {
 
-    private static final int N = 10_000_000;
+    @Param({"10000000"})
+    private int N;
 
-    private static List<String> DATA_FOR_TESTING = createData();
+    private List<String> DATA_FOR_TESTING = createData();
 
     public static void main(String[] argv) throws RunnerException {
         Options opt = new OptionsBuilder()
@@ -30,23 +33,28 @@ public class BenchmarkForwardReverseLoop {
         new Runner(opt).run();
     }
 
+    @Setup
+    public void setup(){
+        DATA_FOR_TESTING = createData();
+    }
+
     @Benchmark
-    public void forwardLoop() {
+    public void forwardLoop(Blackhole bh) {
         for (int i = 0; i < DATA_FOR_TESTING.size(); i++) {
-            String s = DATA_FOR_TESTING.get(i);
+            bh.consume(DATA_FOR_TESTING.get(i));
             //System.out.println(s);
         }
     }
 
     @Benchmark
-    public void reverseLoop() {
+    public void reverseLoop(Blackhole bh) {
         for (int i = DATA_FOR_TESTING.size() - 1; i >= 0; i--) {
-            String s = DATA_FOR_TESTING.get(i);
+            bh.consume(DATA_FOR_TESTING.get(i));
             //System.out.println(s);
         }
     }
 
-    private static List<String> createData() {
+    private List<String> createData() {
         List<String> data = new ArrayList<>();
         for (int i = 0; i < N; i++) {
             data.add("Number : " + i);

--- a/src/main/java/com/mkyong/benchmark/BenchmarkLoop.java
+++ b/src/main/java/com/mkyong/benchmark/BenchmarkLoop.java
@@ -1,6 +1,7 @@
 package com.mkyong.benchmark;
 
 import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
 import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.RunnerException;
 import org.openjdk.jmh.runner.options.Options;
@@ -16,14 +17,16 @@ http://hg.openjdk.java.net/code-tools/jmh/file/tip/jmh-samples/src/main/java/org
 */
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Benchmark)
 @Fork(value = 2, jvmArgs = {"-Xms2G", "-Xmx2G"})
 //@Warmup(iterations = 3)
 //@Measurement(iterations = 8)
 public class BenchmarkLoop {
 
-    private static final int N = 10_000_000;
+    @Param({"10000000"})
+    private int N;
 
-    private static List<String> DATA_FOR_TESTING = createData();
+    private List<String> DATA_FOR_TESTING;
 
     public static void main(String[] args) throws RunnerException {
 
@@ -35,37 +38,43 @@ public class BenchmarkLoop {
         new Runner(opt).run();
     }
 
+    @Setup
+    public void setup(){
+        DATA_FOR_TESTING = createData();
+    }
+
     @Benchmark
-    public void loopFor() {
+    public void loopFor(Blackhole bh) {
         for (int i = 0; i < DATA_FOR_TESTING.size(); i++) {
-            String s = DATA_FOR_TESTING.get(i);
+            bh.consume(DATA_FOR_TESTING.get(i));
         }
     }
 
     @Benchmark
-    public void loopWhile() {
+    public void loopWhile(Blackhole bh) {
         int i = 0;
         while (i < DATA_FOR_TESTING.size()) {
-            String s = DATA_FOR_TESTING.get(i);
+            bh.consume(DATA_FOR_TESTING.get(i));
             i++;
         }
     }
 
     @Benchmark
-    public void loopForEach() {
+    public void loopForEach(Blackhole bh) {
         for (String s : DATA_FOR_TESTING) {
+            bh.consume(s);
         }
     }
 
     @Benchmark
-    public void loopIterator() {
+    public void loopIterator(Blackhole bh) {
         Iterator<String> iterator = DATA_FOR_TESTING.iterator();
         while (iterator.hasNext()) {
-            String next = iterator.next();
+            bh.consume(iterator.next());
         }
     }
 
-    private static List<String> createData() {
+    private List<String> createData() {
 
         List<String> data = new ArrayList<>();
         for (int i = 0; i < N; i++) {


### PR DESCRIPTION
Hi.

To make benchmarks more fair I made some modification:
1. In previous version` String s` don't use at all so compilers can simply remove it. So I add blackhole for this
2. Add setup -> always use setup annotation -> cause without it JIT compiler can for some weird cases precompute value and you will see bizzare results

For you further investigation please take a look
1. Examples and some corener cases - https://hg.openjdk.java.net/code-tools/jmh/file/tip/jmh-samples/src/main/java/org/openjdk/jmh/samples/
2. Take a look on test reverse loop vs forward loop and you will see that reverse loop gives better perfomance -> link for more infromation (https://arnaudroger.github.io/blog/2017/06/15/forward-vs-backward-loop.html)

Alse after this modification times changes and error decreased drammatically.
In previous version
`BenchmarkLoop.loopForEach   avgt    5  59.556 ± 13.788  ms/op`
Now
`BenchmarkLoop.loopForEach   10000000  avgt    5  88.617 ± 2.079  ms/op`
